### PR TITLE
Adds support for automatic doc generation for file-less rules

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -71,10 +71,19 @@ be null or undefined in order to be ignored.
 
 ### reset
 
-By default, all rules are turned on unless explicitly
-set to `false`. When `reset: true`, the opposite is true:
-all rules are turned off, unless when given a non-nully and
-non-false value.
+````md
+  <!-- Explicitly activate rules: -->
+    ```json
+    {
+      "reset": true,
+      "final-newline": true
+    }
+    ```
+````
+
+By default, all rules are turned on unless explicitly set to `false`.
+When `reset: true`, the opposite is true: all rules are turned off,
+unless when given a non-nully and non-false value.
 
 Options: `boolean`, default: `false`.
 

--- a/lib/rules/meta.js
+++ b/lib/rules/meta.js
@@ -1,6 +1,0 @@
-module.exports = {
-  'reset': {
-    description: 'By default, all rules are turned on unless explicitly set to `false`.\nWhen `reset: true`, the opposite is true: all rules are turned off,\nunless when given a non-nully and non-false value.',
-    example: 'reset: true\n<!-- Now you need to explicitly activate rules -->\nfinal-newline: true\n'
-  }
-};

--- a/lib/rules/meta.js
+++ b/lib/rules/meta.js
@@ -1,0 +1,6 @@
+module.exports = {
+  'reset': {
+    description: 'By default, all rules are turned on unless explicitly set to `false`.\nWhen `reset: true`, the opposite is true: all rules are turned off,\nunless when given a non-nully and non-false value.',
+    example: 'reset: true\n<!-- Now you need to explicitly activate rules -->\nfinal-newline: true\n'
+  }
+};

--- a/script/additional.json
+++ b/script/additional.json
@@ -1,0 +1,6 @@
+{
+  "reset": {
+    "description": "By default, all rules are turned on unless explicitly set to `false`.\nWhen `reset: true`, the opposite is true: all rules are turned off,\nunless when given a non-nully and non-false value.\n\nOptions: `boolean`, default: `false`.",
+    "example": "    <!-- Explicitly activate rules: -->\n    ```json\n    {\n      \"reset\": true,\n      \"final-newline\": true\n    }\n    ```\n"
+  }
+}


### PR DESCRIPTION
@wooorm Currently the TOC is with list style stars (`*`) but `mdas-toc` yields dashes (`-`) for me.
According to it's repo `dash` is the correct style.

Thus I haven't added the generator output here. Will do after clarification.

While pushing I thought about just creating empty `<rule-id>.js` files with nothing more than comments in it, so the auto-generation works.

Because for this approach here I'd also like a way to not store its texts inline.